### PR TITLE
ITPL-9910 Correctly return callback when run query returns an error

### DIFF
--- a/lib/create-common-client.js
+++ b/lib/create-common-client.js
@@ -21,12 +21,17 @@ module.exports = function (config) {
           cb();
         },
         runQuery: function (query, cb) {
-          this.knex.raw(query).then(function(resp) {
-            if(config.driver === 'mysql') {
-              cb(null, {rows: resp[0], fields: resp[1]});
-            } else if (config.driver === 'pg' || config.driver === 'pg.js') {
-              cb(null, resp);
-            }
+          this.knex.raw(query).asCallback(function(err, resp) {
+              if(err) {
+                cb(err);
+              }
+              else {
+                if(config.driver === 'mysql') {
+                  cb(null, {rows: resp[0], fields: resp[1]});
+                } else if (config.driver === 'pg' || config.driver === 'pg.js') {
+                  cb(null, resp);
+                }
+              }
           });
         },
         endConnection: function (cb) {


### PR DESCRIPTION
Original isse:
If an sql error occurs then the error callback won't be returned to the caller

Proposed changes:
Change from knex.then to knex.asCallback to not mix using callbacks and promises
Return any errors that occur to the caller

@i-Sight/product-team  