### PR TITLE
[ITPL-39079] Drop support for unused db drivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This project is a fork of the official postgrator module (originally forked off version 2.5.0), aiming to add suport for isight knex migrations
 
+## [5.0.3] - 2025-05-20
+- Drop support for all database drivers, but pg. (ITPL-39079)
+
 ## [5.0.2] - 2025-01-10
 - Upgraded dependencies to resolve vulnerability issues (ITPL-35178)
 

--- a/lib/create-common-client.js
+++ b/lib/create-common-client.js
@@ -1,7 +1,8 @@
 // aka "universal" client
 // here we'll wrap each of the database drivers in a unified interface
 
-var supportedDrivers = ['oracle', 'pg', 'pg.js', 'mysql', 'mssql', 'tedious'];
+
+var supportedDrivers = ['pg'];
 
 module.exports = function (config) {
 
@@ -13,7 +14,7 @@ module.exports = function (config) {
 
     var commonClient = {
         connected: false,
-        dbDriver: null,
+        dbDriver: require('pg'),
         dbConnection: null,
         knex: config.knex,
         schemaTable: config.schemaTable,
@@ -22,13 +23,7 @@ module.exports = function (config) {
         },
         runQuery: function (query, cb) {
           this.knex.raw(query).then(function(resp) {
-            if(config.driver === 'mysql') {
-              cb(null, {rows: resp[0], fields: resp[1]});
-            } else if (config.driver === 'pg' || config.driver === 'pg.js') {
               cb(null, resp);
-            } else if (config.driver === 'oracle') {
-              cb(null, resp);
-            }
           });
         },
         endConnection: function (cb) {
@@ -43,36 +38,8 @@ module.exports = function (config) {
         }
     };
 
-    if (config.driver == 'mysql') {
-
-        commonClient.dbDriver = require('mysql');
-
-        commonClient.queries.checkTable = "SELECT * FROM information_schema.tables WHERE table_schema = '" + config.database + "' AND table_name = '" + config.schemaTable + "';";
-        commonClient.queries.makeTable = "CREATE TABLE " + config.schemaTable + " (version INT, PRIMARY KEY (version)); INSERT INTO " + config.schemaTable + " (version) VALUES (0);";
-
-        if(!commonClient.knex) {
-          commonClient.createConnection = function (cb) {
-            var connection = {
-              multipleStatements: true,
-              host: config.host,
-              user: config.username,
-              password: config.password,
-              database: config.database
-            };
-
-            commonClient.knex = knex({
-              client: 'mysql',
-              connection: connection
-            });
-
-            cb();
-          };
-        }
-
-
-    } else if (config.driver === 'pg' || config.driver === 'pg.js') {
-
-        commonClient.dbDriver = require('pg.js');
+     if (config.driver === 'pg') {    
+        commonClient.dbDriver = require('pg')
 
         var connectionString = config.connectionString || "tcp://" + config.username + ":" + config.password + "@" + config.host + "/" + config.database;
 
@@ -84,70 +51,6 @@ module.exports = function (config) {
             commonClient.knex = knex({
               client: 'pg',
               connection: connectionString
-            });
-
-            cb();
-          };
-        }
-
-    } else if (config.driver == 'mssql' || config.driver == 'tedious') {
-
-        commonClient.dbDriver = require('mssql');
-        
-        var oneHour = 1000 * 60 * 60;
-        
-        var sqlconfig = {
-            user: config.username,
-            password: config.password,
-            server: config.host,
-            database: config.database,
-            options: config.options,
-            requestTimeout: oneHour
-        };
-
-        commonClient.queries.getCurrentVersion = 'SELECT TOP 1 version FROM ' + config.schemaTable + ' ORDER BY version DESC';
-        commonClient.queries.checkTable = "SELECT * FROM information_schema.tables WHERE table_schema = 'dbo' AND table_name = '" + config.schemaTable + "'";
-        commonClient.queries.makeTable = "CREATE TABLE " + config.schemaTable + " (version BIGINT PRIMARY KEY); INSERT INTO " + config.schemaTable + " (version) VALUES (0);";
-
-        commonClient.createConnection = function (cb) {
-            commonClient.dbConnection = commonClient.dbDriver.connect(sqlconfig, function (err) {
-                cb(err);
-            });
-        };
-
-        commonClient.runQuery = function (query, cb) {
-            var request = new commonClient.dbDriver.Request();
-            request.batch(query, function (err, result) {
-                cb(err, {rows: result});
-            });
-        };
-
-        commonClient.endConnection = function (cb) {
-            commonClient.dbConnection.close();
-            cb();
-        };
-
-    } else if (config.driver == 'oracle') {
-
-        commonClient.dbDriver = require('oracle');
-
-        commonClient.queries.getCurrentVersion = 'SELECT * FROM (SELECT "version" FROM "' + config.schemaTable + '" ORDER BY "version" DESC)' + ' WHERE ROWNUM<2';
-        commonClient.queries.checkTable = "SELECT * FROM ALL_OBJECTS WHERE object_type = 'TABLE' AND object_name = '" + config.schemaTable + "'";
-        commonClient.queries.makeTable = 'CREATE TABLE "' + config.schemaTable + '" (version NUMBER(38,0) PRIMARY KEY); INSERT INTO "' + config.schemaTable + '" ("version") VALUES (0);';
-
-        var connection = {
-                    host: config.host,
-                    port: config.port,
-                    user: config.username,
-                    password: config.password,
-                    database: config.database
-        };
-
-        if(!commonClient.knex) {
-          commonClient.createConnection = function (cb) {
-            commonClient.knex = knex({
-              client: 'oracle',
-              connection: connection
             });
 
             cb();

--- a/package.json
+++ b/package.json
@@ -20,12 +20,8 @@
     "bluebird": "3.7.2",
     "knex": "3.1.0",
     "lodash": "4.17.21",
-    "mssql": "3.3.0",
-    "mysql": "2.14.1",
     "newline": "0.0.3",
-    "oracle": "0.x.x",
-    "pg": "8.x.x",
-    "pg.js": "4.x.x"
+    "pg": "8.x.x"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postgrator",
-  "version": "5.0.2-caseiq",
+  "version": "5.0.3-caseiq",
   "author": "Case IQ",
   "description": "Postgrator is a SQL migration tool for SQL people",
   "keywords": [

--- a/postgrator.js
+++ b/postgrator.js
@@ -5,7 +5,7 @@
     var postgrator = require('postgrator');
 
     postgrator.setConfig({
-        driver: 'pg', // or pg.js, mysql, mssql, tedious
+        driver: 'pg',
         migrationDirectory: '',
         logProgress: true,
         schemaTable: '', // default is 'schemaversion'
@@ -320,12 +320,12 @@ var getRelevantMigrations = function (currentVersion, targetVersion) {
 				migration.knexjs = require(config.migrationDirectory + '/' + migration.filename)['do'];
 			}
 
-			if ((migration.action == 'do' || migration.action == 'knex') && migration.version > 0 && migration.version <= currentVersion && (config.driver === 'pg' || config.driver === 'pg.js')) {
+			if ((migration.action == 'do' || migration.action == 'knex') && migration.version > 0 && migration.version <= currentVersion && config.driver === 'pg') {
 				migration.md5Sql = 'SELECT md5 FROM ' + config.schemaTable + ' WHERE version = ' + migration.version + ';';
 				relevantMigrations.push(migration);
 			}
 			if ((migration.action == 'do' || migration.action == 'knex') && migration.version > currentVersion && migration.version <= targetVersion) {
-				migration.schemaVersionSQL = config.driver === 'pg' || config.driver === 'pg.js' ? "INSERT INTO "+config.schemaTable+" (version, name, md5) VALUES (" + migration.version + ", '" + migration.name + "', '" + migration.md5 + "');" : "INSERT INTO " + config.schemaTable + " (version) VALUES (" + migration.version + ");";
+				migration.schemaVersionSQL = config.driver === 'pg' ? "INSERT INTO "+config.schemaTable+" (version, name, md5) VALUES (" + migration.version + ", '" + migration.name + "', '" + migration.md5 + "');" : "INSERT INTO " + config.schemaTable + " (version) VALUES (" + migration.version + ");";
 				relevantMigrations.push(migration);
 			}
 		});
@@ -410,7 +410,7 @@ function prep (callback) {
 			callback(err);
 		} else {
 			if ((result.rows && result.rows.length > 0) || (result && result.length > 0)) {
-				if (config.driver === 'pg' || config.driver === 'pg.js') {
+				if (config.driver === 'pg') {
 					// config.schemaTable exists, does it have the md5 column? (PostgreSQL only)
 					runQuery("SELECT column_name, data_type, character_maximum_length FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name = '" + config.schemaTable + "' AND column_name = 'md5';", function (err, result) {
 						if (err) {

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # Postgrator
 
 A Node.js SQL migration tool using a directory of plain SQL or knex scripts. 
-Supports Postgres, MySQL, and SQL Server.
+Supports Postgres only.
 
 Case IQ fork
 
@@ -40,7 +40,7 @@ var postgrator = require('postgrator');
 postgrator.setConfig({
     migrationDirectory: __dirname + '/migrations', 
     schemaTable: 'schemaversion', // optional. default is 'schemaversion'
-    driver: 'pg', // or pg.js, mysql, mssql, tedious
+    driver: 'pg',
     host: '127.0.0.1',
     database: 'databasename',
     username: 'username',
@@ -82,7 +82,7 @@ For SQL Server, you may optionally provide an additional options configuration. 
 postgrator.setConfig({
     migrationDirectory: __dirname + '/migrations', 
     schemaTable: 'schemaversion', // optional. default is 'schemaversion'
-    driver: 'pg', // or pg.js, mysql, mssql, tedious
+    driver: 'pg',
     host: '127.0.0.1',
     database: 'databasename',
     username: 'username',
@@ -99,11 +99,7 @@ Reference options for mssql for more details: [https://www.npmjs.com/package/mss
 
 ## Compatible Drivers
 
-Acceptable values for **driver** are: pg, pg.js, mysql, tedious, or mssql (the last 2 being MS SQL Server drivers). 
-
-Despite the driver specified, Postgrator will use either pg.js, mysql, or mssql (which is wrapper around tedious) behind the scenes. All these drivers are purely javascript based, requiring no extra compilation. 
-
-
+Acceptable values for **driver** are: pg. 
 
 ## Version 2.0 Notes
 
@@ -138,7 +134,7 @@ Line feeds: Unix/Mac uses LF, Windows uses 'CRLF', this causes problems for post
 ```
 postgrator.setConfig({
     migrationDirectory: __dirname + '/migrations', 
-    driver: 'pg', // or pg.js, mysql, mssql, tedious
+    driver: 'pg',
     host: '127.0.0.1',
     database: 'databasename',
     username: 'username',

--- a/test/test-postgrator.js
+++ b/test/test-postgrator.js
@@ -16,7 +16,7 @@ tests.push(function (callback) {
 	console.log('\n----- testing original api to 003 -----');
 	var postgrator = require('../postgrator.js');
 	postgrator.setConfig({
-        driver: 'pg.js',
+        driver: 'pg',
         migrationDirectory: __dirname + '/migrations',
         connectionString: pgUrl
     });
@@ -30,7 +30,7 @@ tests.push(function (callback) {
 	console.log('\n----- testing original api to 000 -----');
 	var postgrator = require('../postgrator.js');
 	postgrator.setConfig({
-        driver: 'pg.js',
+        driver: 'pg',
         migrationDirectory: __dirname + '/migrations',
         connectionString: pgUrl
     });
@@ -149,33 +149,13 @@ var buildTestsForConfig = function (config) {
 
 buildTestsForConfig({
 	migrationDirectory: __dirname + '/migrations',
-	driver: 'pg.js',
+	driver: 'pg',
 	host: 'localhost',
 	database: DB_NAME,
 	username: DB_USER,
 	password: DB_PASS,
 });
 
-
-// buildTestsForConfig({
-// 	migrationDirectory: __dirname + '/migrations',
-// 	driver: 'mysql',
-// 	host: 'localhost',
-// 	database: 'test',
-// 	username: 'root',
-// 	password: ''
-// });
-
-/*
-buildTestsForConfig({
-	migrationDirectory: __dirname + '/migrations',
-	driver: 'tedious',
-	host: '127.0.0.1',
-	database: 'Utility',
-	username: 'testuser',
-	password: 'testuser'
-});
-*/
 
 /* Run the tests in an asyncy way
 ============================================================================= */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,50 +2,15 @@
 # yarn lockfile v1
 
 
-asap@~2.0.3:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
-  integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
-
 async@3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.6.tgz#1b0728e14929d51b85b449b7f06e27c1145e38ce"
   integrity sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==
 
-babel-runtime@^5.8.19:
-  version "5.8.38"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-5.8.38.tgz#1c0b02eb63312f5f087ff20450827b425c9d4c19"
-  integrity sha1-HAsC62MxL18If/IEUIJ7QlydTBk=
-  dependencies:
-    core-js "^1.0.0"
-
-big-number@0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/big-number/-/big-number-0.3.1.tgz#ac73020c0a59bb79eb17c2ce2db77f77d974e013"
-  integrity sha1-rHMCDApZu3nrF8LOLbd/d9l04BM=
-
-bignumber.js@4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-4.0.2.tgz#2d1dc37ee5968867ecea90b6da4d16e68608d21d"
-  integrity sha1-LR3DfuWWiGfs6pC22k0W5oYI0h0=
-
-bl@^1.0.0:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.2.tgz#a160911717103c07410cef63ef51b397c025af9c"
-  integrity sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==
-  dependencies:
-    readable-stream "^2.3.5"
-    safe-buffer "^5.1.1"
-
 bluebird@3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
-
-buffer-writer@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/buffer-writer/-/buffer-writer-1.0.0.tgz#6c29c3b2dea0c9e455a1f261a199a48a04f88b08"
-  integrity sha1-bCnDst6gyeRVofJhoZmkigT4iwg=
 
 colorette@2.0.19:
   version "2.0.19"
@@ -56,16 +21,6 @@ commander@^10.0.0:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
   integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
-
-core-js@^1.0.0:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
-  integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
-
-core-util-is@~1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
-  integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
 debug@4.3.4:
   version "4.3.4"
@@ -89,16 +44,6 @@ function-bind@^1.1.2:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
-generic-pool@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-2.1.1.tgz#af04dc2c325cfcb975023fa52bfce9617a7435fd"
-  integrity sha1-rwTcLDJc/Ll1Aj+lK/zpYXp0Nf0=
-
-generic-pool@^2.2.0:
-  version "2.5.4"
-  resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-2.5.4.tgz#38c6188513e14030948ec6e5cf65523d9779299b"
-  integrity sha1-OMYYhRPhQDCUjsblz2VSPZd5KZs=
-
 get-package-type@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
@@ -116,18 +61,6 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
-iconv-lite@^0.4.11:
-  version "0.4.24"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
-  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3"
-
-inherits@~2.0.3:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
-  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
-
 interpret@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
@@ -139,11 +72,6 @@ is-core-module@^2.13.0:
   integrity sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==
   dependencies:
     hasown "^2.0.2"
-
-isarray@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
-  integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
 knex@3.1.0:
   version "3.1.0"
@@ -175,39 +103,10 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-mssql@3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/mssql/-/mssql-3.3.0.tgz#b6e6337ff123e87bf8aee1e6c8344b53ca5da856"
-  integrity sha1-tuYzf/Ej6Hv4ruHmyDRLU8pdqFY=
-  dependencies:
-    generic-pool "^2.2.0"
-    promise "^7.0.1"
-    tedious "~1.14.0"
-
-mysql@2.14.1:
-  version "2.14.1"
-  resolved "https://registry.yarnpkg.com/mysql/-/mysql-2.14.1.tgz#e9324015e810a50abda94855cab41edfad56284a"
-  integrity sha512-ZPXqQeYH7L1QPDyC77Rcp32cNCQnNjz8Y4BbF17tOjm5yhSfjFa3xS4PvuxWJtEEmwVc4ccI7sSntj4eyYRq0A==
-  dependencies:
-    bignumber.js "4.0.2"
-    readable-stream "2.3.3"
-    safe-buffer "5.1.1"
-    sqlstring "2.2.0"
-
 newline@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/newline/-/newline-0.0.3.tgz#0f6a74493223dba04fe7dbfb6cdc804bf7e46dd0"
   integrity sha1-D2p0STIj26BP59v7bNyAS/fkbdA=
-
-oracle@0.x.x:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/oracle/-/oracle-0.4.1.tgz#e25729c291a707f899314606c861280978451aad"
-  integrity sha1-4lcpwpGnB/iZMUYGyGEoCXhFGq0=
-
-packet-reader@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/packet-reader/-/packet-reader-0.2.0.tgz#819df4d010b82d5ea5671f8a1a3acf039bcd7700"
-  integrity sha1-gZ300BC4LV6lZx+KGjrPA5vNdwA=
 
 path-parse@^1.0.7:
   version "1.0.7"
@@ -218,11 +117,6 @@ pg-cloudflare@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/pg-cloudflare/-/pg-cloudflare-1.1.1.tgz#e6d5833015b170e23ae819e8c5d7eaedb472ca98"
   integrity sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==
-
-pg-connection-string@0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-0.1.3.tgz#da1847b20940e42ee1492beaf65d49d91b245df7"
-  integrity sha1-2hhHsglA5C7hSSvq9l1J2RskXfc=
 
 pg-connection-string@2.6.2:
   version "2.6.2"
@@ -249,11 +143,6 @@ pg-protocol@^1.7.0:
   resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.7.0.tgz#ec037c87c20515372692edac8b63cf4405448a93"
   integrity sha512-hTK/mE36i8fDDhgDFjy6xNOG+LCorxLG3WO17tku+ij6sVHXh1jQUJ8hYAnRhNla4QVD2H8er/FOjc/+EgC6yQ==
 
-pg-types@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/pg-types/-/pg-types-1.6.0.tgz#3872a0f199143025497f4ee2a65fdaf00d7ea8b3"
-  integrity sha1-OHKg8ZkUMCVJf07ipl/a8A1+qLM=
-
 pg-types@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/pg-types/-/pg-types-2.2.0.tgz#2d0250d636454f7cfa3b6ae0382fdfa8063254a3"
@@ -264,18 +153,6 @@ pg-types@^2.1.0:
     postgres-bytea "~1.0.0"
     postgres-date "~1.0.4"
     postgres-interval "^1.1.0"
-
-pg.js@4.x.x:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/pg.js/-/pg.js-4.1.1.tgz#654033ae706b31d44be1443883b2a5f9aae9cfc4"
-  integrity sha1-ZUAzrnBrMdRL4UQ4g7Kl+arpz8Q=
-  dependencies:
-    buffer-writer "1.0.0"
-    generic-pool "2.1.1"
-    packet-reader "0.2.0"
-    pg-connection-string "0.1.3"
-    pg-types "1.6.0"
-    pgpass "0.0.3"
 
 pg@8.x.x:
   version "8.13.1"
@@ -289,13 +166,6 @@ pg@8.x.x:
     pgpass "1.x"
   optionalDependencies:
     pg-cloudflare "^1.1.1"
-
-pgpass@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/pgpass/-/pgpass-0.0.3.tgz#12e67e343b3189c2f31206ebc9cc0befffcf9140"
-  integrity sha1-EuZ+NDsxicLzEgbrycwL7//PkUA=
-  dependencies:
-    split "~0.3"
 
 pgpass@1.x:
   version "1.0.2"
@@ -326,49 +196,6 @@ postgres-interval@^1.1.0:
   dependencies:
     xtend "^4.0.0"
 
-process-nextick-args@~1.0.6:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
-  integrity sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=
-
-process-nextick-args@~2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
-  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
-
-promise@^7.0.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
-  integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
-  dependencies:
-    asap "~2.0.3"
-
-readable-stream@2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
-  integrity sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.3"
-    isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.0.3"
-    util-deprecate "~1.0.1"
-
-readable-stream@^2.0.2, readable-stream@^2.3.5:
-  version "2.3.7"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
-  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.3"
-    isarray "~1.0.0"
-    process-nextick-args "~2.0.0"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.1.1"
-    util-deprecate "~1.0.1"
-
 rechoir@^0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.8.0.tgz#49f866e0d32146142da3ad8f0eff352b3215ff22"
@@ -390,68 +217,12 @@ resolve@^1.20.0:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
-safe-buffer@5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
-  integrity sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==
-
-safe-buffer@^5.1.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
-  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
-
-safe-buffer@~5.1.0, safe-buffer@~5.1.1:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
-  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
-
-"safer-buffer@>= 2.1.2 < 3":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
-  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
-
-semver@^5.1.0:
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
-  integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
-
 split@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/split/-/split-1.0.1.tgz#605bd9be303aa59fb35f9229fbea0ddec9ea07d9"
   integrity sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==
   dependencies:
     through "2"
-
-split@~0.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
-  integrity sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=
-  dependencies:
-    through "2"
-
-sprintf@0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/sprintf/-/sprintf-0.1.5.tgz#8f83e39a9317c1a502cb7db8050e51c679f6edcf"
-  integrity sha1-j4PjmpMXwaUCy324BQ5Rxnn27c8=
-
-sqlstring@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/sqlstring/-/sqlstring-2.2.0.tgz#c3135c4ea8abcd7e7ee741a4966a891d86a4f191"
-  integrity sha1-wxNcTqirzX5+50GklmqJHYak8ZE=
-
-string_decoder@~1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
-  integrity sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==
-  dependencies:
-    safe-buffer "~5.1.0"
-
-string_decoder@~1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
-  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
-  dependencies:
-    safe-buffer "~5.1.0"
 
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
@@ -463,19 +234,6 @@ tarn@^3.0.2:
   resolved "https://registry.yarnpkg.com/tarn/-/tarn-3.0.2.tgz#73b6140fbb881b71559c4f8bfde3d9a4b3d27693"
   integrity sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==
 
-tedious@~1.14.0:
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/tedious/-/tedious-1.14.0.tgz#c05c303b8668cf91e55a6493b744866af61987de"
-  integrity sha1-wFwwO4Zoz5HlWmSTt0SGavYZh94=
-  dependencies:
-    babel-runtime "^5.8.19"
-    big-number "0.3.1"
-    bl "^1.0.0"
-    iconv-lite "^0.4.11"
-    readable-stream "^2.0.2"
-    semver "^5.1.0"
-    sprintf "0.1.5"
-
 through@2:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
@@ -485,11 +243,6 @@ tildify@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/tildify/-/tildify-2.0.0.tgz#f205f3674d677ce698b7067a99e949ce03b4754a"
   integrity sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw==
-
-util-deprecate@~1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-  integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
 xtend@^4.0.0:
   version "4.0.2"


### PR DESCRIPTION
#### Original issue (Brief description of original problem)
- node-gyp failures when building the docker image on the main repo.
- node-gyp is required by native modules and postgrator has oracle as one its dependencies
  - Oracle is not being used by the main repo, we only use pg 

#### Changes proposed (Brief description of solution and how it addresses the problem)
- Drop support for all drivers, but pg.


